### PR TITLE
Fix: Ensure environment variables are loaded in agent tmux sessions

### DIFF
--- a/silica/cli/commands/agent.py
+++ b/silica/cli/commands/agent.py
@@ -37,10 +37,13 @@ def agent(workspace):
             f"[green]Connecting to agent tmux session: [bold]{app_name}[/bold][/green]"
         )
 
-        # Escape the tmux command properly
+        # Use 'piku shell' pipe to ensure login shell environment is loaded
+        # Then create or attach to tmux session with environment variables preserved
+        tmux_cmd = f"tmux new-session -A -s {app_name} './AGENT.sh; exec bash'"
         run_piku_in_silica(
-            f"tmux new-session -A -s {app_name} './AGENT.sh; exec bash'",
+            tmux_cmd,
             workspace_name=workspace,
+            use_shell_pipe=True,  # Use shell pipe to ensure env vars are loaded
         )
 
     except Exception as e:

--- a/silica/utils/templates/AGENT.sh
+++ b/silica/utils/templates/AGENT.sh
@@ -2,6 +2,19 @@
 # Get the directory where this script is located
 TOP=$(cd $(dirname $0) && pwd)
 
+# Load environment variables
+if [ -f ~/.profile ]; then
+    . ~/.profile
+fi
+if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+fi
+
+# Load piku-specific environment
+if [ -f ~/.piku_env ]; then
+    . ~/.piku_env
+fi
+
 # Synchronize dependencies
 cd "${TOP}"
 uv sync

--- a/silica/utils/templates/AGENT.sh
+++ b/silica/utils/templates/AGENT.sh
@@ -2,19 +2,6 @@
 # Get the directory where this script is located
 TOP=$(cd $(dirname $0) && pwd)
 
-# Load environment variables
-if [ -f ~/.profile ]; then
-    . ~/.profile
-fi
-if [ -f ~/.bashrc ]; then
-    . ~/.bashrc
-fi
-
-# Load piku-specific environment
-if [ -f ~/.piku_env ]; then
-    . ~/.piku_env
-fi
-
 # Synchronize dependencies
 cd "${TOP}"
 uv sync


### PR DESCRIPTION
## Summary

When starting the agent tmux session, the environment variables were not being loaded properly, though they were accessible when using [31mError: app 'pikupiku4' not found.[0m. This PR fixes this issue by changing how the tmux session is started in .

## Root Cause Analysis

The issue stemmed from the fact that running a command via SSH directly would not load the environment variables unless specifically set up as a login shell. When we run [31mError: app 'pikupiku4' not found.[0m, it properly sets up an interactive login shell, whereas the direct tmux command execution did not.

## The Fix

The fix is simple but effective - we now use  when calling  to start the tmux session. This ensures the tmux session is launched through the proper login shell initialization process provided by [31mError: app 'pikupiku4' not found.[0m, which correctly loads all environment variables.

## Testing

1. Create a new agent/workspace with environment variables set
2. Connect to the agent using Connecting to agent tmux session: agent-silica
Unexpected error: No .silica directory found in this repository
3. Verify environment variables are properly accessible within the session