### PR TITLE
feat: update all GITHUB_TOKEN references to GH_TOKEN

### DIFF
--- a/docs/YAML_AGENTS.md
+++ b/docs/YAML_AGENTS.md
@@ -30,7 +30,7 @@ environment:
   required:
     - name: "API_KEY"
       description: "Required API key for the service"
-    - name: "GITHUB_TOKEN"
+    - name: "GH_TOKEN"
       description: "GitHub token for repository access"
   recommended:
     - name: "OPTIONAL_KEY"
@@ -63,7 +63,7 @@ environment:
       description: "Anthropic API key for Claude access"
     - name: "BRAVE_SEARCH_API_KEY" 
       description: "Brave Search API key for web search functionality"
-    - name: "GITHUB_TOKEN"
+    - name: "GH_TOKEN"
       description: "GitHub token for repository access"
   recommended:
     - name: "OPENAI_API_KEY"
@@ -86,7 +86,7 @@ dependencies:
   - "aider-chat"
 environment:
   required:
-    - name: "GITHUB_TOKEN"
+    - name: "GH_TOKEN"
       description: "GitHub token for repository access"
   recommended:
     - name: "OPENAI_API_KEY"

--- a/silica/agents/aider.yaml
+++ b/silica/agents/aider.yaml
@@ -23,7 +23,7 @@
 # - pip install aider-chat
 #
 # Required Environment Variables:
-# - GITHUB_TOKEN: For repository access and operations
+# - GH_TOKEN: For repository access and operations
 #
 # Recommended Environment Variables:
 # - OPENAI_API_KEY: For GPT model access (preferred)
@@ -43,7 +43,7 @@ dependencies:
   - "aider-chat"
 environment:
   required:
-    - name: "GITHUB_TOKEN"
+    - name: "GH_TOKEN"
       description: "GitHub token for repository access"
   recommended:
     - name: "OPENAI_API_KEY"

--- a/silica/agents/claude-code.yaml
+++ b/silica/agents/claude-code.yaml
@@ -16,7 +16,7 @@
 #
 # Required Environment Variables:
 # - ANTHROPIC_API_KEY: For Claude API access
-# - GITHUB_TOKEN: For repository operations
+# - GH_TOKEN: For repository operations
 #
 name: "claude-code"
 description: "Claude Code - Anthropic's coding assistant"
@@ -33,5 +33,5 @@ environment:
   required:
     - name: "ANTHROPIC_API_KEY"
       description: "Anthropic API key for Claude access"
-    - name: "GITHUB_TOKEN"
+    - name: "GH_TOKEN"
       description: "GitHub token for repository access"

--- a/silica/agents/cline.yaml
+++ b/silica/agents/cline.yaml
@@ -21,7 +21,7 @@
 # - Requires Node.js and npm
 #
 # Required Environment Variables:
-# - GITHUB_TOKEN: For repository access and operations
+# - GH_TOKEN: For repository access and operations
 #
 # Recommended Environment Variables:
 # - ANTHROPIC_API_KEY: For Claude model access (preferred)
@@ -40,7 +40,7 @@ dependencies:
   - "cline"
 environment:
   required:
-    - name: "GITHUB_TOKEN"
+    - name: "GH_TOKEN"
       description: "GitHub token for repository access"
   recommended:
     - name: "ANTHROPIC_API_KEY"

--- a/silica/agents/hdev.yaml
+++ b/silica/agents/hdev.yaml
@@ -19,7 +19,7 @@
 # Required Environment Variables:
 # - ANTHROPIC_API_KEY: For Claude AI model access
 # - BRAVE_SEARCH_API_KEY: For web search functionality  
-# - GITHUB_TOKEN: For repository operations
+# - GH_TOKEN: For repository operations
 #
 # Optional Environment Variables:
 # - OPENAI_API_KEY: For additional model access
@@ -46,7 +46,7 @@ environment:
       description: "Anthropic API key for Claude access"
     - name: "BRAVE_SEARCH_API_KEY" 
       description: "Brave Search API key for web search functionality"
-    - name: "GITHUB_TOKEN"
+    - name: "GH_TOKEN"
       description: "GitHub token for repository access"
   recommended:
     - name: "OPENAI_API_KEY"

--- a/silica/agents/openai-codex.yaml
+++ b/silica/agents/openai-codex.yaml
@@ -17,7 +17,7 @@
 #
 # Required Environment Variables:
 # - OPENAI_API_KEY: For Codex API access
-# - GITHUB_TOKEN: For repository operations
+# - GH_TOKEN: For repository operations
 #
 name: "openai-codex"
 description: "OpenAI Codex - AI coding assistant"
@@ -34,5 +34,5 @@ environment:
   required:
     - name: "OPENAI_API_KEY"
       description: "OpenAI API key for Codex access"
-    - name: "GITHUB_TOKEN"
+    - name: "GH_TOKEN"
       description: "GitHub token for repository access"

--- a/silica/cli/commands/config.py
+++ b/silica/cli/commands/config.py
@@ -240,7 +240,7 @@ def setup():
     # Check and configure various API keys
     api_keys = {
         "ANTHROPIC_API_KEY": "Anthropic API key",
-        "GITHUB_TOKEN": "GitHub token",
+        "GH_TOKEN": "GitHub token",
         "BRAVE_SEARCH_API_KEY": "Brave Search API key",
     }
 

--- a/silica/cli/commands/create.py
+++ b/silica/cli/commands/create.py
@@ -325,11 +325,7 @@ def create(workspace, connection, agent_type):
             )
 
         # Set up GitHub authentication if a GitHub token is available
-        gh_token = None
-        for key in ["GITHUB_TOKEN", "GH_TOKEN"]:
-            if key in env_config:
-                gh_token = env_config[key]
-                break
+        gh_token = env_config.get("GH_TOKEN")
 
         if gh_token:
             console.print("Setting up GitHub authentication in the code directory...")

--- a/silica/config/__init__.py
+++ b/silica/config/__init__.py
@@ -12,7 +12,7 @@ DEFAULT_CONFIG = {
     "default_agent": "hdev",
     "api_keys": {
         "ANTHROPIC_API_KEY": None,
-        "GITHUB_TOKEN": None,
+        "GH_TOKEN": None,
         "BRAVE_SEARCH_API_KEY": None,
     },
 }


### PR DESCRIPTION
## Summary

Updated all references of `GITHUB_TOKEN` to `GH_TOKEN` throughout the silica codebase to align with GitHub CLI's preferred environment variable naming convention.

## Changes Made

### Files Modified:
- **docs/YAML_AGENTS.md** - Updated documentation examples to use GH_TOKEN
- **silica/config/__init__.py** - Updated default configuration
- **silica/agents/*.yaml** - Updated all agent configurations (cline, openai-codex, aider, claude-code, hdev)
- **silica/cli/commands/config.py** - Updated API key configuration
- **silica/cli/commands/create.py** - Simplified GitHub auth setup to only look for GH_TOKEN

### Technical Details:
- Replaced all `GITHUB_TOKEN` references with `GH_TOKEN` in environment variable definitions
- Updated comments and documentation to reflect the change
- Simplified the GitHub authentication logic in create.py to remove backward compatibility check
- All agent YAML files now consistently use GH_TOKEN
- Default configuration now uses GH_TOKEN instead of GITHUB_TOKEN

## Testing
- ✅ All existing tests pass (18/18)
- ✅ YAML syntax validation passed for all modified agent files
- ✅ Python syntax validation passed for all modified Python files
- ✅ Pre-commit hooks (autoflake, ruff, ruff-format) all passed

## Rationale
`GH_TOKEN` is the standard environment variable name used by GitHub CLI and many GitHub integrations. This change improves consistency with the broader GitHub ecosystem.

## Backward Compatibility
This is a breaking change for users who have `GITHUB_TOKEN` configured. Users will need to update their environment variable from `GITHUB_TOKEN` to `GH_TOKEN`. This should be communicated in release notes.