### PR TITLE
Require WORKSPACE_NAME environment variable in remote deployments

### DIFF
--- a/silica/remote/antennae/config.py
+++ b/silica/remote/antennae/config.py
@@ -19,7 +19,13 @@ class AntennaeConfig:
 
     def get_workspace_name_from_env(self) -> str:
         """Get workspace name from environment (dynamic)."""
-        return os.environ.get("WORKSPACE_NAME", "agent")
+        workspace_name = os.environ.get("WORKSPACE_NAME")
+        if not workspace_name:
+            raise RuntimeError(
+                "WORKSPACE_NAME environment variable must be set. "
+                "This should be configured automatically during remote workspace creation."
+            )
+        return workspace_name
 
     @property
     def code_directory(self) -> Path:

--- a/silica/remote/cli/commands/antennae.py
+++ b/silica/remote/cli/commands/antennae.py
@@ -10,15 +10,16 @@ import cyclopts
 
 
 def antennae(
-    port: Annotated[
-        int, cyclopts.Parameter(help="Port to run the antennae webapp on")
-    ] = 8000,
     workspace: Annotated[
         str,
         cyclopts.Parameter(
-            name=["--workspace", "-w"], help="Name of the workspace to manage"
+            name=["--workspace", "-w"],
+            help="Name of the workspace to manage (required)",
         ),
-    ] = "agent",
+    ],
+    port: Annotated[
+        int, cyclopts.Parameter(help="Port to run the antennae webapp on")
+    ] = 8000,
     host: Annotated[
         str, cyclopts.Parameter(help="Host address to bind to")
     ] = "0.0.0.0",

--- a/silica/remote/utils/templates/Procfile
+++ b/silica/remote/utils/templates/Procfile
@@ -1,1 +1,1 @@
-web: uv run silica remote antennae --port $PORT --workspace ${WORKSPACE_NAME:-agent}
+web: uv run silica remote antennae --port $PORT --workspace $WORKSPACE_NAME

--- a/tests/remote/test_antennae_webapp.py
+++ b/tests/remote/test_antennae_webapp.py
@@ -20,12 +20,15 @@ class TestAntennaeConfig:
             config = AntennaeConfig()
             assert config.get_workspace_name() == "test-workspace"
 
-    def test_workspace_name_default(self):
-        """Test default workspace name when not in environment."""
+    def test_workspace_name_required(self):
+        """Test that workspace name is required - raises error when not set."""
         # Ensure WORKSPACE_NAME is not set
         with patch.dict(os.environ, {}, clear=True):
             config = AntennaeConfig()
-            assert config.get_workspace_name() == "agent"
+            with pytest.raises(
+                RuntimeError, match="WORKSPACE_NAME environment variable must be set"
+            ):
+                config.get_workspace_name()
 
     def test_directory_paths(self):
         """Test directory path configuration."""

--- a/uv.lock
+++ b/uv.lock
@@ -936,6 +936,21 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456", size = 497003, upload-time = "2025-02-13T21:54:07.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25", size = 238051, upload-time = "2025-02-13T21:54:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da", size = 239535, upload-time = "2025-02-13T21:54:16.07Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ed/d362e84620dd22876b55389248e522338ed1bf134a5edd3b8231d7207f6d/psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91", size = 275004, upload-time = "2025-02-13T21:54:18.662Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34", size = 277986, upload-time = "2025-02-13T21:54:21.811Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/709e0fe2f093556c17fbafda93ac032257242cabcc7ff3369e2cb76a97aa/psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993", size = 279544, upload-time = "2025-02-13T21:54:24.68Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e6/eecf58810b9d12e6427369784efe814a1eec0f492084ce8eb8f4d89d6d61/psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99", size = 241053, upload-time = "2025-02-13T21:54:34.31Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553", size = 244885, upload-time = "2025-02-13T21:54:37.486Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1090,6 +1105,7 @@ dependencies = [
     { name = "markdownify" },
     { name = "pathspec" },
     { name = "prompt-toolkit" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
@@ -1141,6 +1157,7 @@ requires-dist = [
     { name = "pathspec", specifier = ">=0.12.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
+    { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Problem

Remote workspaces were creating tmux sessions named `agent-agent` instead of proper workspace-specific names like `{workspace-name}-agent` when the `WORKSPACE_NAME` environment variable wasn't properly set. This was due to silent fallbacks to "agent" as a default value.

## Solution

Remove all default values for `WORKSPACE_NAME` to ensure fail-fast behavior and explicit configuration:

### Changes Made

1. **Procfile Template**: Removed `:-agent` fallback from `${WORKSPACE_NAME:-agent}`
2. **Antennae CLI**: Made `--workspace` parameter required (no default value)  
3. **AntennaeConfig**: Now raises `RuntimeError` if `WORKSPACE_NAME` is not set
4. **Tests**: Updated to verify error handling for missing environment variable

### Benefits

- **Fail Fast**: Configuration issues are caught immediately with clear error messages
- **Explicit Configuration**: No silent fallbacks to "agent" that could cause confusion
- **Better Debugging**: Missing `WORKSPACE_NAME` is immediately obvious
- **Consistent Naming**: Ensures tmux sessions have proper names

## Testing

- ✅ All existing tests pass with updated expectations
- ✅ Manual verification shows proper error handling when WORKSPACE_NAME is missing
- ✅ Command line interface properly requires workspace parameter
- ✅ Remote workspace creation continues to work as before (properly sets WORKSPACE_NAME)

## Impact

- Remote workspace creation via `silica remote create` continues to work as before
- Manual antennae usage now requires explicit `--workspace` parameter
- Improper deployments fail fast with clear error message instead of creating confusing session names