### PR TITLE
Display antennae version in create and status commands

### DIFF
--- a/silica/remote/cli/commands/create.py
+++ b/silica/remote/cli/commands/create.py
@@ -561,6 +561,18 @@ def create_remote_workspace(
                     console.print(
                         "[green]Workspace initialized successfully with repository![/green]"
                     )
+
+                    # Try to get status to show version information
+                    try:
+                        status_success, status_response = client.get_status()
+                        if status_success:
+                            antennae_version = status_response.get("version", "old")
+                            console.print(
+                                f"[dim]Antennae version: {antennae_version}[/dim]"
+                            )
+                    except Exception:
+                        # Don't fail the create process if we can't get status
+                        pass
                 else:
                     error_msg = response.get("error", "Unknown error")
                     detail = response.get("detail", "")
@@ -885,6 +897,15 @@ def create_local_workspace(
             console.print(f"[yellow]Could not connect to antennae server: {e}[/yellow]")
 
         if antennae_running:
+            # Show version info since server is running
+            try:
+                status_success, status_response = client.get_status()
+                if status_success:
+                    antennae_version = status_response.get("version", "old")
+                    console.print(f"[dim]Antennae version: {antennae_version}[/dim]")
+            except Exception:
+                pass
+
             # Get current git repository details
             try:
                 import git
@@ -922,6 +943,19 @@ def create_local_workspace(
                         console.print(
                             "[green]Workspace initialized successfully![/green]"
                         )
+
+                        # Try to get status to show version information
+                        try:
+                            status_success, status_response = client.get_status()
+                            if status_success:
+                                antennae_version = status_response.get("version", "old")
+                                console.print(
+                                    f"[dim]Antennae version: {antennae_version}[/dim]"
+                                )
+                        except Exception:
+                            # Don't fail the create process if we can't get status
+                            pass
+
                         console.print(
                             "[green bold]Local workspace created and initialized![/green bold]"
                         )

--- a/silica/remote/cli/commands/status.py
+++ b/silica/remote/cli/commands/status.py
@@ -227,6 +227,11 @@ def print_single_workspace_status(status: Dict[str, Any], detailed: bool = False
 
     console.print("[green]✅ Antennae webapp is accessible[/green]")
 
+    # Show version information
+    status_info = status.get("status_info", {})
+    antennae_version = status_info.get("version") or "old"
+    console.print(f"[dim]Antennae version: {antennae_version}[/dim]")
+
     # Get status info from HTTP response
     status_info = status.get("status_info", {})
     connection_info = status.get("connection_info", {})
@@ -299,6 +304,7 @@ def print_all_workspaces_summary(statuses: List[Dict[str, Any]]):
     table.add_column("Accessible", style="green")
     table.add_column("Repository", style="blue")
     table.add_column("Agent Session", style="yellow")
+    table.add_column("Version", style="bright_black")
     table.add_column("Status", style="red")
 
     for status in statuses:
@@ -313,11 +319,13 @@ def print_all_workspaces_summary(statuses: List[Dict[str, Any]]):
         # Check repository status
         repo_status = "[yellow]Unknown[/yellow]"
         session_status = "[yellow]Unknown[/yellow]"
+        antennae_version = "old"
 
         if status["accessible"] and status["status_info"]:
             status_info = status["status_info"]
             repo_info = status_info.get("repository", {})
             tmux_info = status_info.get("tmux_session", {})
+            antennae_version = status_info.get("version") or "old"
 
             if repo_info.get("exists", False):
                 repo_status = "[green]✅[/green]"
@@ -342,6 +350,7 @@ def print_all_workspaces_summary(statuses: List[Dict[str, Any]]):
             accessible,
             repo_status,
             session_status,
+            antennae_version,
             overall_status,
         )
 


### PR DESCRIPTION
## Summary

This PR enhances the  and  commands to display the antennae version from remote workspaces, providing better visibility for debugging and support.

## Changes Made

### Status Command Enhancements
- **Added version display in detailed workspace view**: Shows antennae version below accessibility status
- **Added version column to summary table**: New "Version" column in the workspace status table
- **Graceful fallback**: Defaults to "old" when version information is unavailable

### Create Command Enhancements
- **Version display after successful creation**: Shows antennae version after workspace initialization
- **Robust error handling**: Version display doesn't fail the creation process if status call fails
- **Consistent across workspace types**: Both local and remote workspace creation show version info

## Technical Implementation

- Leverages the  API endpoint that now includes version information (from PR #34)
- Uses  to fetch version data from antennae webapp
- Implements fallback logic: 
- Added version column to Rich table with  styling for subtle appearance

## User Experience

### Before


### After  


### Summary Table


## Testing

- ✅ All existing antennae webapp tests pass
- ✅ Manual testing confirms version display works correctly
- ✅ Error handling gracefully falls back to "old" when version unavailable
- ✅ Code formatting and linting passes

## Benefits

- **Improved debugging**: Users can quickly identify which silica version is running on remote workspaces
- **Better support**: Support teams can easily determine workspace versions
- **Consistent tracking**: Version information available across create and status workflows
- **Non-breaking**: Graceful fallbacks ensure commands work with older antennae instances