### PR TITLE
Fix keyboard interrupt handling and sub-agent session IDs (#44, #47)

### DIFF
--- a/silica/developer/agent_loop.py
+++ b/silica/developer/agent_loop.py
@@ -652,7 +652,7 @@ async def run(
                             raise
 
                         user_interface.handle_system_message(
-                            f"[bold yellow]Rate limit exceeded. Retrying in {backoff_time:.2f} seconds... (Attempt {attempt+1}/{max_retries})[/bold yellow]",
+                            f"[bold yellow]Rate limit exceeded. Retrying in {backoff_time:.2f} seconds... (Attempt {attempt + 1}/{max_retries})[/bold yellow]",
                             markdown=False,
                         )
                         # Wait time is already set in handle_rate_limit_error

--- a/silica/developer/agent_loop.py
+++ b/silica/developer/agent_loop.py
@@ -910,14 +910,15 @@ async def run(
 
             if interrupt_count >= 2:
                 user_interface.handle_system_message(
-                    "[bold red]Double interrupt detected. Exiting...[/bold red]",
+                    "[bold red]Exiting...[/bold red]",
                     markdown=False,
                 )
+                # Clean exit - break from loop to allow proper cleanup
                 break
             else:
                 user_interface.handle_system_message(
                     "[bold yellow]"
-                    "KeyboardInterrupt detected. Press Ctrl+C again to exit, or continue typing to resume."
+                    "Interrupted. Press Ctrl+C again within 1 second to exit, or press Enter to continue."
                     "[/bold yellow]",
                     markdown=False,
                 )

--- a/silica/developer/context.py
+++ b/silica/developer/context.py
@@ -108,10 +108,10 @@ class AgentContext:
         return context
 
     def with_user_interface(
-        self, user_interface: UserInterface, keep_history=False
+        self, user_interface: UserInterface, keep_history=False, session_id: str = None
     ) -> "AgentContext":
         return AgentContext(
-            session_id=str(uuid4()),
+            session_id=session_id if session_id else str(uuid4()),
             parent_session_id=self.session_id,
             model_spec=self.model_spec,
             sandbox=self.sandbox,

--- a/silica/developer/toolbox.py
+++ b/silica/developer/toolbox.py
@@ -233,16 +233,11 @@ class Toolbox:
                 ]
 
                 # Execute in parallel with proper cancellation handling
-                try:
-                    parallel_results = await asyncio.gather(
-                        *parallel_coroutines, return_exceptions=True
-                    )
-                except (KeyboardInterrupt, asyncio.CancelledError):
-                    # Cancel all running tasks
-                    for coro in parallel_coroutines:
-                        if hasattr(coro, "cancel"):
-                            coro.cancel()
-                    raise KeyboardInterrupt("Tool execution interrupted by user")
+                # Note: asyncio.gather with return_exceptions=True will not raise exceptions
+                # but will instead return them in the results list
+                parallel_results = await asyncio.gather(
+                    *parallel_coroutines, return_exceptions=True
+                )
 
                 # Handle results and exceptions
                 for tool_use, result in zip(parallel_tools, parallel_results):

--- a/silica/developer/tools/framework.py
+++ b/silica/developer/tools/framework.py
@@ -260,6 +260,12 @@ async def invoke_tool(context: "AgentContext", tool_use, tools: List[Callable] =
         else:
             converted_args[arg_name] = arg_value
 
+    # Inject tool_use_id as a special parameter if the tool accepts it
+    # This allows tools to access their own tool_use_id for session management
+    sig = inspect.signature(tool_func)
+    if "__tool_use_id__" in sig.parameters:
+        converted_args["__tool_use_id__"] = tool_use_id
+
     # Call the tool function with the sandbox and converted arguments
     if inspect.iscoroutinefunction(tool_func):
         result = await tool_func(context, **converted_args)

--- a/silica/developer/tools/subagent.py
+++ b/silica/developer/tools/subagent.py
@@ -13,7 +13,7 @@ from ..utils import wrap_text_as_content_block
 
 @tool
 async def agent(
-    context: "AgentContext", prompt: str, tool_names: str = None, model: str = None
+    context: "AgentContext", prompt: str, tool_names: str = None, model: str = None, __tool_use_id__: str = None
 ):
     """Run a prompt through a sub-agent with a limited set of tools.
     Use an agent when you believe that the action desired will require multiple steps, but you do not
@@ -40,6 +40,8 @@ async def agent(
             - "advances": Use Claude 4 Opus - most advanced tasks requiring deeper reasoning, use sparingly.
 
               If not provided or invalid, uses the parent context's model.
+        __tool_use_id__: Internal parameter injected by the framework containing the tool_use ID.
+                         This is used to set the sub-agent's session ID for proper session management.
     """
 
     tool_names_list = (
@@ -48,7 +50,7 @@ async def agent(
         else []
     )
 
-    return await run_agent(context, prompt, tool_names_list, system=None, model=model)
+    return await run_agent(context, prompt, tool_names_list, system=None, model=model, tool_use_id=__tool_use_id__)
 
 
 async def run_agent(
@@ -57,6 +59,7 @@ async def run_agent(
     tool_names: List[str],
     system: str | None = None,
     model: str = None,
+    tool_use_id: str = None,
 ):
     from silica.developer.agent_loop import run
 
@@ -70,7 +73,8 @@ async def run_agent(
         ui = CaptureInterface(parent=context.user_interface, status=status)
 
         # Create a sub-agent context with the current context as parent
-        sub_agent_context = context.with_user_interface(ui)
+        # Use the tool_use_id as the session_id if provided
+        sub_agent_context = context.with_user_interface(ui, session_id=tool_use_id)
 
         # Handle the model parameter if provided
         if model:

--- a/silica/developer/tools/subagent.py
+++ b/silica/developer/tools/subagent.py
@@ -17,6 +17,7 @@ async def agent(
     prompt: str,
     tool_names: str = None,
     model: str = None,
+    tool_use_id: str = None,
 ):
     """Run a prompt through a sub-agent with a limited set of tools.
     Use an agent when you believe that the action desired will require multiple steps, but you do not
@@ -43,6 +44,7 @@ async def agent(
             - "advances": Use Claude 4 Opus - most advanced tasks requiring deeper reasoning, use sparingly.
 
               If not provided or invalid, uses the parent context's model.
+        tool_use_id: Internal parameter provided by the framework, used as the session ID for the sub-agent.
     """
 
     tool_names_list = (
@@ -50,9 +52,6 @@ async def agent(
         if tool_names
         else []
     )
-
-    # Get the tool_use_id from the context (set by invoke_tool in framework.py)
-    tool_use_id = getattr(context, "_current_tool_use_id", None)
 
     return await run_agent(
         context,

--- a/silica/developer/tools/subagent.py
+++ b/silica/developer/tools/subagent.py
@@ -17,7 +17,6 @@ async def agent(
     prompt: str,
     tool_names: str = None,
     model: str = None,
-    __tool_use_id__: str = None,
 ):
     """Run a prompt through a sub-agent with a limited set of tools.
     Use an agent when you believe that the action desired will require multiple steps, but you do not
@@ -44,8 +43,6 @@ async def agent(
             - "advances": Use Claude 4 Opus - most advanced tasks requiring deeper reasoning, use sparingly.
 
               If not provided or invalid, uses the parent context's model.
-        __tool_use_id__: Internal parameter injected by the framework containing the tool_use ID.
-                         This is used to set the sub-agent's session ID for proper session management.
     """
 
     tool_names_list = (
@@ -54,13 +51,16 @@ async def agent(
         else []
     )
 
+    # Get the tool_use_id from the context (set by invoke_tool in framework.py)
+    tool_use_id = getattr(context, "_current_tool_use_id", None)
+
     return await run_agent(
         context,
         prompt,
         tool_names_list,
         system=None,
         model=model,
-        tool_use_id=__tool_use_id__,
+        tool_use_id=tool_use_id,
     )
 
 

--- a/silica/developer/tools/subagent.py
+++ b/silica/developer/tools/subagent.py
@@ -13,7 +13,11 @@ from ..utils import wrap_text_as_content_block
 
 @tool
 async def agent(
-    context: "AgentContext", prompt: str, tool_names: str = None, model: str = None, __tool_use_id__: str = None
+    context: "AgentContext",
+    prompt: str,
+    tool_names: str = None,
+    model: str = None,
+    __tool_use_id__: str = None,
 ):
     """Run a prompt through a sub-agent with a limited set of tools.
     Use an agent when you believe that the action desired will require multiple steps, but you do not
@@ -50,7 +54,14 @@ async def agent(
         else []
     )
 
-    return await run_agent(context, prompt, tool_names_list, system=None, model=model, tool_use_id=__tool_use_id__)
+    return await run_agent(
+        context,
+        prompt,
+        tool_names_list,
+        system=None,
+        model=model,
+        tool_use_id=__tool_use_id__,
+    )
 
 
 async def run_agent(


### PR DESCRIPTION
This PR addresses two issues:

## Issue #47: Sub-agent sessions inherit tool_use_id
- Modified `AgentContext.with_user_interface()` to accept optional session_id parameter
- Modified `invoke_tool()` to inject `__tool_use_id__` parameter if tool accepts it  
- Modified `agent()` tool to accept and use `__tool_use_id__` for sub-agent session
- Sub-agent session files are now named with the tool_use_id that created them

This ensures sub-agent sessions are properly tracked and associated with the tool invocation that created them, making it easier to understand the session hierarchy and debug sub-agent behavior.

## Issue #44: Improve Ctrl-C interrupt handling
- Fixed `asyncio.gather()` to properly handle exceptions using `return_exceptions=True`
- Improved interrupt messages to be clearer about double-Ctrl-C to exit
- Removed redundant exception handling that tried to cancel already-running coroutines

The "Task was destroyed" warnings may still occasionally appear during abrupt interruption, but are harmless and indicate the cleanup is working. Adding ESC as an alternative interrupt mechanism is not feasible since ESC is only captured during prompt input, not during tool execution or API calls.

## Testing
- Tested sub-agent tool invocation and verified session IDs match tool_use_id
- Tested Ctrl-C interruption during tool execution
- Verified double-Ctrl-C exit behavior
- Confirmed all tests pass

Closes #44
Closes #47