### PR TITLE
Optimize test performance - 41% faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,28 @@ workspaces:
       args: {}
 ```
 
+## Development
+
+### Running Tests
+
+```bash
+# Run all tests
+pytest
+
+# Run only fast tests (excludes slow integration tests)
+pytest -m "not slow"
+
+# Run with verbose output and show slowest tests
+pytest -v --durations=10
+```
+
+The test suite includes markers for different test types:
+- `slow`: Integration tests that take longer to run (tmux operations, subprocess timeouts)
+- `integration`: Tests requiring external resources
+- `safe`: Tests with no side effects
+
+For faster development iteration, use `pytest -m "not slow"` to run only the fast tests (~43s vs ~82s for the full suite).
+
 ## Compatibility
 
 This update maintains backward compatibility with existing silica workspaces. When you run commands with the updated version:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -29,6 +29,7 @@ class TestPromptScheduler:
         assert scheduler.agent_model == "sonnet"
         assert scheduler.silica_timeout == 600
 
+    @pytest.mark.slow
     @patch("silica.cron.scheduler.SessionLocal")
     def test_start_stop_scheduler(self, mock_session_local):
         """Test starting and stopping the scheduler."""

--- a/tests/developer/test_cli_keyboard_input_fix.py
+++ b/tests/developer/test_cli_keyboard_input_fix.py
@@ -92,6 +92,7 @@ class MockUserInterface(UserInterface):
         pass
 
 
+@pytest.mark.slow
 class TestCLIKeyboardInputFix:
     """Test suite for CLI keyboard input responsiveness fixes."""
 

--- a/tests/developer/test_interactive_bash_timeout.py
+++ b/tests/developer/test_interactive_bash_timeout.py
@@ -71,6 +71,7 @@ class MockUserInterface(UserInterface):
         pass
 
 
+@pytest.mark.slow
 class TestInteractiveBashTimeout:
     """Test suite for interactive bash timeout functionality."""
 

--- a/tests/developer/test_tmux_timeout.py
+++ b/tests/developer/test_tmux_timeout.py
@@ -182,8 +182,17 @@ class TestTimeoutFunctionality:
         session = TmuxSession("test", "tmux_test")
         self.manager.sessions["test"] = session
 
-        # Mock successful command execution
-        mock_run_command.return_value = (0, "", "")
+        # Mock command execution and completion check with proper prompt
+        def mock_command_side_effect(cmd):
+            if "send-keys" in cmd:
+                return (0, "", "")
+            elif "capture-pane" in cmd:
+                # Return output with prompt to indicate command completion
+                return (0, "echo hello\nhello\n❯ ", "")
+            else:
+                return (0, "", "")
+
+        mock_run_command.side_effect = mock_command_side_effect
 
         # Valid timeout
         success, message = self.manager.execute_command("test", "echo hello", timeout=5)

--- a/tests/developer/test_tmux_timeout.py
+++ b/tests/developer/test_tmux_timeout.py
@@ -220,6 +220,7 @@ class TestTimeoutFunctionality:
         assert "Command executed" in message
 
 
+@pytest.mark.slow
 class TestTimeoutToolIntegration:
     """Integration tests for timeout functionality with tool functions."""
 

--- a/tests/remote/test_antennae_client_retry.py
+++ b/tests/remote/test_antennae_client_retry.py
@@ -161,8 +161,9 @@ workspaces:
         assert "HTTP 404" in response["error"]
         assert mock_get.call_count == 3  # Initial attempt + 2 retries
 
+    @patch("time.sleep")
     @patch("requests.post")
-    def test_initialize_uses_retries(self, mock_post, antennae_client):
+    def test_initialize_uses_retries(self, mock_post, mock_sleep, antennae_client):
         """Test that initialize method uses retry logic correctly."""
         # First two attempts return 404 (app starting), third succeeds
         mock_response_404 = Mock()
@@ -277,8 +278,9 @@ workspaces:
 
             yield silica_dir
 
+    @patch("time.sleep")
     @patch("requests.post")
-    def test_piku_app_startup_simulation(self, mock_post, temp_silica_dir):
+    def test_piku_app_startup_simulation(self, mock_post, mock_sleep, temp_silica_dir):
         """Simulate a realistic piku app startup scenario."""
         client = get_antennae_client(temp_silica_dir, "test-workspace")
 
@@ -327,8 +329,11 @@ workspaces:
                 "branch": "main",
             }
 
+    @patch("time.sleep")
     @patch("requests.post")
-    def test_piku_app_never_starts_scenario(self, mock_post, temp_silica_dir):
+    def test_piku_app_never_starts_scenario(
+        self, mock_post, mock_sleep, temp_silica_dir
+    ):
         """Simulate scenario where piku app never becomes available."""
         client = get_antennae_client(temp_silica_dir, "test-workspace")
 


### PR DESCRIPTION
## Summary
Diagnoses and fixes slow test performance, reducing total test time by 41%.

## Changes
1. **Mock time.sleep in retry tests** - Antennae client retry tests were performing actual sleeps during exponential backoff, wasting ~48 seconds
2. **Fix timeout validation test mock** - Improper mocking caused 5-second timeout wait
3. **Mark slow integration tests** - Allow developers to skip slow tests with `pytest -m "not slow"`
4. **Add documentation** - Document test running options in README

## Results
- Full test suite: 129s → 76s (41% faster)
- Fast tests only: 32s (519/541 tests)
- CI/CD will complete much faster
- Better developer experience during iteration

## Testing
- All 541 tests still pass
- No functionality compromised
- Verified improvements with `--durations` flag

Closes #52