### PR TITLE
fix: compaction uses wrong context window for pass-through models

### DIFF
--- a/scripts/compaction_tester.py
+++ b/scripts/compaction_tester.py
@@ -235,7 +235,7 @@ class CompactionTester:
 
         # Count tokens
         token_count = self.compacter.count_tokens(context, model)
-        context_window = self.compacter.model_context_windows.get(model, 200000)
+        context_window = self.compacter.get_context_window(model)
         threshold = int(context_window * self.compacter.threshold_ratio)
 
         print("\nToken Analysis:")

--- a/silica/developer/agent_loop.py
+++ b/silica/developer/agent_loop.py
@@ -938,10 +938,9 @@ async def run(
                                     pass
                                 else:
                                     # Get context window size for this model
+                                    # (handles pass-through/unknown model names)
                                     context_window_for_display = (
-                                        compacter.model_context_windows.get(
-                                            model_name, 100000
-                                        )
+                                        compacter.get_context_window(model_name)
                                     )
 
                                     # Count tokens for complete conversation

--- a/silica/developer/compacter.py
+++ b/silica/developer/compacter.py
@@ -45,6 +45,11 @@ class CompactionMetadata:
     original_token_count: int
     summary_token_count: int
     compaction_ratio: float
+    # Real API-counted context size before/after compaction (includes
+    # system prompt + tools). Optional because legacy code paths may not
+    # populate them.
+    total_tokens_before: int | None = None
+    total_tokens_after: int | None = None
 
 
 class ConversationCompacter:
@@ -106,11 +111,35 @@ class ConversationCompacter:
         self.logger = logger
         self.client = client
 
-        # Get model context window information
+        # Override dict for model context windows (primarily for testing).
+        # Runtime lookups should go through get_context_window() which falls
+        # back to get_model() for models not in this dict (e.g. pass-through
+        # model names like internal/preview models that aren't in MODEL_MAP).
         self.model_context_windows = {
-            model_data["title"]: model_data.get("context_window", 100000)
+            model_data["title"]: model_data.get("context_window", 200000)
             for model_data in [get_model(ms) for ms in model_names()]
         }
+
+    def get_context_window(self, model: str) -> int:
+        """Get the context window size for a model.
+
+        Checks the model_context_windows override dict first (so tests can
+        inject known values), then falls back to get_model() which correctly
+        handles pass-through/unknown model names by returning a sensible
+        default (200k) rather than the previous hardcoded 100k.
+
+        Args:
+            model: Model name, alias, or full model ID
+
+        Returns:
+            Context window size in tokens
+        """
+        # Resolve alias -> title so override-dict keys match
+        model_spec = get_model(model)
+        title = model_spec["title"]
+        if title in self.model_context_windows:
+            return self.model_context_windows[title]
+        return model_spec.get("context_window", 200000)
 
     def count_tokens(self, agent_context, model: str, messages: list = None) -> int:
         """Count tokens for the complete context sent to the API.
@@ -543,8 +572,8 @@ class ConversationCompacter:
         # Use accurate token counting method
         token_count = self.count_tokens(agent_context, model)
 
-        # Get context window size for this model, default to 100k if not found
-        context_window = self.model_context_windows.get(model, 100000)
+        # Get context window size for this model (handles pass-through models)
+        context_window = self.get_context_window(model)
 
         # Calculate threshold based on context window and threshold ratio
         token_threshold = int(context_window * self.threshold_ratio)
@@ -1116,6 +1145,10 @@ Focus on preserving what the guidance identifies as important. Be comprehensive 
         # Calculate tokens to remove for target reduction
         # We want: (total - removed_tokens) / total <= (1 - target_reduction_ratio)
         # So: removed_tokens >= total * target_reduction_ratio
+        # Note: if this exceeds message_tokens (irreducible base dominates),
+        # the loop below falls through and we compact as much as possible,
+        # which is the best we can do. That pathological case is avoided in
+        # practice by the 200k context window (see get_context_window()).
         tokens_to_remove = int(total_tokens * target_reduction_ratio)
 
         if debug:
@@ -1204,6 +1237,13 @@ Focus on preserving what the guidance identifies as important. Be comprehensive 
         # Check if compaction should proceed
         if not force and not self.should_compact(agent_context, model):
             return None
+
+        # Capture real token count before compaction for accurate reporting.
+        # Fall back to None on error so compaction itself isn't blocked.
+        try:
+            tokens_before = self.count_tokens(agent_context, model)
+        except Exception:
+            tokens_before = None
 
         # Check if debug mode is enabled
         debug_compaction = os.getenv("SILICA_DEBUG_COMPACTION", "").lower() in (
@@ -1316,6 +1356,14 @@ Focus on preserving what the guidance identifies as important. Be comprehensive 
 
         # Update metadata with the actual archive name
         metadata.archive_name = archive_name
+
+        # Capture real token count after compaction (context has been rotated
+        # in place by _archive_and_rotate). Best-effort.
+        try:
+            metadata.total_tokens_after = self.count_tokens(agent_context, model)
+        except Exception:
+            metadata.total_tokens_after = None
+        metadata.total_tokens_before = tokens_before
 
         return metadata
 
@@ -1535,6 +1583,8 @@ Focus on preserving what the guidance identifies as important. Be comprehensive 
                         print("[Compaction] Not needed yet")
                         return agent_context, False
 
+            # Note: compact_conversation() has its own should_compact() gate
+            # internally, so the debug-only check above is purely for logging.
             # Use the session's own model for compaction so that any thinking
             # blocks in the conversation are compatible with the compaction model.
             metadata = self.compact_conversation(
@@ -1558,15 +1608,26 @@ Focus on preserving what the guidance identifies as important. Be comprehensive 
                         return f"{tokens / 1000:.0f}K"
                     return str(tokens)
 
-                orig_tokens = format_tokens(metadata.original_token_count)
-                summary_tokens = format_tokens(metadata.summary_token_count)
+                # Prefer real API-counted context size before/after. Fall back
+                # to the legacy prefix-estimate if real counts are unavailable.
+                if (
+                    metadata.total_tokens_before is not None
+                    and metadata.total_tokens_after is not None
+                ):
+                    before_tokens = format_tokens(metadata.total_tokens_before)
+                    after_tokens = format_tokens(metadata.total_tokens_after)
+                    token_part = f"ctx {before_tokens} → {after_tokens} tokens"
+                else:
+                    before_tokens = format_tokens(metadata.original_token_count)
+                    after_tokens = format_tokens(metadata.summary_token_count)
+                    token_part = f"{before_tokens} → {after_tokens} tokens"
 
                 # Notify user about the compaction with compact summary
                 user_interface.handle_system_message(
                     f"[bold green]✓ Compacted: "
                     f"{metadata.original_message_count} msgs → {metadata.compacted_message_count} msgs "
                     f"({msg_reduction_pct:.0f}% reduction) | "
-                    f"{orig_tokens} → {summary_tokens} tokens | "
+                    f"{token_part} | "
                     f"archived to {metadata.archive_name}[/bold green]",
                     markdown=False,
                 )

--- a/tests/developer/test_compaction.py
+++ b/tests/developer/test_compaction.py
@@ -128,6 +128,63 @@ class TestConversationCompaction(unittest.TestCase):
         # Should compact should return True because 60000 > 50000 (50% of 100000)
         self.assertTrue(compacter.should_compact(context, "claude-3-5-sonnet-latest"))
 
+    def test_get_context_window_passthrough_model(self):
+        """Regression test: unknown/pass-through model names must not fall back
+        to a 100k context window. They should resolve via get_model() to 200k.
+
+        This was the root cause of compaction thrashing: pass-through models
+        (e.g. internal preview builds) weren't in model_context_windows, so
+        the lookup defaulted to 100k, halving the effective context window
+        and triggering compaction at ~85k instead of ~170k.
+        """
+        compacter = ConversationCompacter(client=mock.MagicMock())
+
+        # Known model by title
+        self.assertEqual(compacter.get_context_window("claude-opus-4-6"), 200000)
+        # Known model by alias
+        self.assertEqual(compacter.get_context_window("sonnet"), 200000)
+        # Unknown / pass-through model name -> must be 200k, NOT 100k
+        self.assertEqual(
+            compacter.get_context_window("some-unknown-model-name"), 200000
+        )
+        # Test override dict still works (tests rely on this)
+        compacter.model_context_windows = {"tiny-model": 50000}
+        self.assertEqual(compacter.get_context_window("tiny-model"), 50000)
+        # And non-overridden models still resolve correctly after override
+        self.assertEqual(compacter.get_context_window("claude-opus-4-6"), 200000)
+
+    def test_should_compact_passthrough_model_uses_200k(self):
+        """Regression test: should_compact with a pass-through model name
+        must use the 200k window, so 120k tokens at 85% threshold (=170k)
+        should NOT trigger compaction.
+        """
+        compacter = ConversationCompacter(threshold_ratio=0.85, client=mock.MagicMock())
+
+        ui = MockUserInterface()
+        sandbox = Sandbox(self.test_dir, mode=SandboxMode.ALLOW_ALL)
+        memory_manager = MemoryManager()
+        context = AgentContext(
+            parent_session_id=None,
+            session_id="test-session",
+            model_spec=self.model_spec,
+            sandbox=sandbox,
+            user_interface=ui,
+            usage=[],
+            memory_manager=memory_manager,
+        )
+        context._chat_history = self.sample_messages
+
+        # 120k tokens: below 170k (85% of 200k) but above 85k (85% of 100k).
+        # Pre-fix, this would erroneously trigger compaction.
+        compacter.count_tokens = mock.MagicMock(return_value=120000)
+        self.assertFalse(
+            compacter.should_compact(context, "some-passthrough-model-v99")
+        )
+
+        # 180k tokens: above 170k -> should compact
+        compacter.count_tokens = mock.MagicMock(return_value=180000)
+        self.assertTrue(compacter.should_compact(context, "some-passthrough-model-v99"))
+
     @mock.patch("anthropic.Client")
     def test_context_flush_with_compaction(self, mock_client_class):
         """Test context flush with compaction."""

--- a/tests/developer/test_token_counting_incomplete_tool_use.py
+++ b/tests/developer/test_token_counting_incomplete_tool_use.py
@@ -257,9 +257,7 @@ class TestTokenCountingIncompleteToolUse(unittest.TestCase):
                 pass
             else:
                 # Get context window size for this model
-                context_window_for_display = compacter.model_context_windows.get(
-                    model_name, 100000
-                )
+                context_window_for_display = compacter.get_context_window(model_name)
 
                 # Count tokens for complete conversation
                 conversation_size_for_display = compacter.count_tokens(


### PR DESCRIPTION
## Summary

Fixes compaction thrashing when running with a model name that isn't in `MODEL_MAP` (e.g. internal/preview pass-through models).

### Observed symptom

```
✓ Compacted: 98 msgs → 4 msgs (96% reduction) | 9K → 1K tokens | archived to pre-compaction-...
in: 17155K (cached: 906662K) | out: 3350K | ctx: 81.1K/100K (81%) | $864.92 | ⏱ 4m16s
```

Two things are wrong here:
1. The status bar shows `ctx: 81.1K/100K` but the model's actual context window is **200K**.
2. The compaction banner claims `9K → 1K tokens` while the status bar shows `81.1K` — the banner number is a word-heuristic estimate of the *compacted prefix only*, not the real context size.

### Root cause

`ConversationCompacter.model_context_windows` is built from `model_names()` (canonical models in `MODEL_MAP` only). Any model name not in that map — a pass-through name — misses the dict and the `.get(model, 100000)` default applies.

With a ~75K irreducible floor (system prompt + tool schemas) and an 85% threshold on a false 100K window (= 85K trigger), compaction fires on nearly every turn. `calculate_turns_for_target_reduction` then can't hit its 30%-of-total target because the floor dominates, so it falls back to compacting the entire history each time.

### Fixes

1. **Context-window lookup** — Add `ConversationCompacter.get_context_window(model)` which checks the `model_context_windows` dict first (kept as a test-override layer) and falls back to `get_model(model)["context_window"]`, which correctly returns 200K for unknown/pass-through names. Use it in `should_compact()` and the `agent_loop` status-bar.

2. **Accurate compaction display** — Capture real `count_tokens()` before and after `compact_conversation()` into new optional `CompactionMetadata.total_tokens_before/after` fields, and display `ctx 82K → 76K tokens` instead of the misleading prefix estimate. Falls back to the legacy display if the real counts are unavailable.

3. Added a clarifying comment that `compact_conversation()` has its own internal `should_compact()` gate (the debug-only check in `check_and_apply_compaction` is purely for logging), and a note in `calculate_turns_for_target_reduction` that the unreachable-target fallback is intentional and moot once the correct window is used.

### Tests

- New regression tests:
  - `test_get_context_window_passthrough_model` — unknown/alias/override resolution → 200K (not 100K)
  - `test_should_compact_passthrough_model_uses_200k` — 120K tokens with a pass-through model does **not** trigger compaction at 85% threshold; 180K does
- All 40 compaction-related tests pass (`test_compaction.py`, `test_smart_compaction.py`, `test_token_counting_incomplete_tool_use.py`, `test_compaction_timing_fix.py`, `test_compaction_non_tool_cycles.py`, `test_compaction_commands.py`)
- `agent_loop` / status-bar tests pass
- pre-commit (autoflake / ruff / ruff-format) clean

### Not changed

- `calculate_turns_for_target_reduction`'s `tokens_to_remove = int(total * ratio)` is left uncapped. I considered capping at `message_tokens`, but the existing fallback (compact everything when the target is unreachable) is the correct best-effort behaviour and capping breaks `/compact` on small conversations. Largely moot once the window is correct anyway.
